### PR TITLE
ci(deploy): Remove environment flag from the validation job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,17 +42,11 @@ env:
     github.event_name == 'release' && github.event.release.tag_name || 'null' }}
   RC_SRC: ${{ vars.DEPLOYMENT_ARTEFACTS_S3_BUCKET }}
   BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ vars.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+  PROD_ASSUME_ROLE_ARN: ${{ vars.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
   validation:
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment ||
-      github.event_name == 'release' && 'prod' ||
-      contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) && (
-        startsWith(github.ref, 'refs/tags/v') && 'prod' ||
-        github.ref_name == 'main' && 'uat' ||
-        github.ref_name == 'test' && 'test'
-      ) || 'dev' }}
     outputs:
       VERSION: ${{ steps.validate.outputs.VERSION }}
 
@@ -80,7 +74,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ env.PROD_ASSUME_ROLE_ARN }}
           role-session-name: ${{ vars.PROJECT_NAME }}-${{ env.RC_ENV }}-app-deploy-validation
           role-duration-seconds: 3600
           role-skip-session-tagging: true
@@ -234,7 +228,7 @@ jobs:
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
-      # Assume a role into the BODS-PROD account
+      # Assume a role into the Environment Specific account
       - name: Configure AWS Credentials in bodds-prod
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
- It's not needed in the validation job
- It was being used to trigger approval requests
- Now the environment flag is used in the deploy job
- Deploy jobs to `uat` and `uat2` will trigger approval requests

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8085