### PR TITLE
feat(state-machine): Add Semaphore Concurrency Limit

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,1 @@
-version: v1.1.60
-
+version: v1.1.61

--- a/state-machine.json
+++ b/state-machine.json
@@ -188,7 +188,7 @@
             "Lambda.SdkClientException",
             "Lambda.TooManyRequestsException"
           ],
-          "IntervalSeconds": 1, 
+          "IntervalSeconds": 1,
           "MaxAttempts": 3,
           "BackoffRate": 2,
           "JitterStrategy": "FULL"
@@ -1256,7 +1256,7 @@
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:updateItem",
       "Arguments": {
-        "TableName": "${DQSTableSemaphore}",
+        "TableName": "${DQSSemaphoreDynamoDbTableName}",
         "Key": {
           "LockName": {
             "S": "{% $lock_name %}"
@@ -1362,10 +1362,10 @@
       "Output": "{% $states.result.Payload %}",
       "Arguments": {
         "FunctionName": "${GeneralErrorLambdaArn}",
-        "Payload":{
+        "Payload": {
           "Error": "{% $states.input %}",
           "revision_id": "{% $revision_id %}"
-          }
+        }
       },
       "Retry": [
         {

--- a/state-machine.json
+++ b/state-machine.json
@@ -1,177 +1,175 @@
 {
   "QueryLanguage": "JSONata",
   "Comment": "Data Quality Service State Machine",
-  "StartAt": "InitialProcessInput",
+  "StartAt": "Initial Process Input",
   "States": {
-    "StartAt": "Initial Process Input",
-    "States": {
-      "Initial Process Input": {
-        "Type": "Pass",
-        "Next": "Validate Lock Inputs",
-        "Assign": {
-          "revision_id": "{% $exists($states.input) ? $states.input : null %}",
-          "lock_name": "dqs-semaphore",
-          "concurrency_limit": 2,
-          "lock_entry": "{% $uuid() %}"
+    "Initial Process Input": {
+      "Type": "Pass",
+      "Next": "Validate Lock Inputs",
+      "Assign": {
+        "revision_id": "{% $exists($states.input) ? $states.input : null %}",
+        "lock_name": "dqs-semaphore",
+        "concurrency_limit": 2,
+        "lock_entry": "{% $uuid() %}"
+      }
+    },
+    "Validate Lock Inputs": {
+      "Type": "Choice",
+      "Default": "Lock Configuration Error",
+      "Choices": [
+        {
+          "Condition": "{% $exists($lock_name) and $type($lock_name) = 'string' and $exists($concurrency_limit) and $type($concurrency_limit) = 'number' and $exists($lock_entry) and $type($lock_entry) = 'string' %}",
+          "Next": "Acquire Lock"
+        }
+      ]
+    },
+    "Lock Configuration Error": {
+      "Type": "Fail",
+      "Error": "InsufficientLockInput",
+      "Cause": "Lock parameters are missing or invalid"
+    },
+    "Acquire Lock": {
+      "Comment": "Acquire a lock using a conditional update to DynamoDB",
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": "${DQSSemaphoreDynamoDbTableName}",
+        "Key": {
+          "LockName": {
+            "S": "{% $lock_name %}"
+          }
+        },
+        "ExpressionAttributeNames": {
+          "#currentlockcount": "currentlockcount",
+          "#lockownerid": "{% $lock_entry %}"
+        },
+        "ExpressionAttributeValues": {
+          ":increase": {
+            "N": "1"
+          },
+          ":limit": {
+            "N": "{% $string($concurrency_limit) %}"
+          },
+          ":lockacquiredtime": {
+            "S": "{% $states.context.State.EnteredTime %}"
+          }
+        },
+        "UpdateExpression": "SET #currentlockcount = #currentlockcount + :increase, #lockownerid = :lockacquiredtime",
+        "ConditionExpression": "currentlockcount <> :limit and attribute_not_exists(#lockownerid)",
+        "ReturnValues": "UPDATED_NEW"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.AmazonDynamoDBException"
+          ],
+          "MaxAttempts": 0
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.AmazonDynamoDBException"
+          ],
+          "Next": "Initialize Lock Item",
+          "Output": "$lockinfo.acquisitionerror"
+        },
+        {
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
+          "Next": "Get Current Lock Record",
+          "Output": "$lockinfo.acquisitionerror"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ParentExceptionHandler",
+          "Output": "$.error"
+        }
+      ],
+      "Next": "Initiate DQS Lambda"
+    },
+    "Initialize Lock Item": {
+      "Comment": "Create the initial lock record if it doesn't exist",
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:putItem",
+      "Arguments": {
+        "TableName": "${DQSSemaphoreDynamoDbTableName}",
+        "Item": {
+          "LockName": {
+            "S": "{% $lock_name %}"
+          },
+          "currentlockcount": {
+            "N": "0"
+          }
+        },
+        "ConditionExpression": "LockName <> :lockname",
+        "ExpressionAttributeValues": {
+          ":lockname": {
+            "S": "{% $lock_name %}"
+          }
         }
       },
-      "Validate Lock Inputs": {
-        "Type": "Choice",
-        "Default": "Lock Configuration Error",
-        "Choices": [
-          {
-            "Condition": "{% $exists($lock_name) and $type($lock_name) = 'string' and $exists($concurrency_limit) and $type($concurrency_limit) = 'number' and $exists($lock_entry) and $type($lock_entry) = 'string' %}",
-            "Next": "Acquire Lock"
-          }
-        ]
-      },
-      "Lock Configuration Error": {
-        "Type": "Fail",
-        "Error": "InsufficientLockInput",
-        "Cause": "Lock parameters are missing or invalid"
-      },
-      "Acquire Lock": {
-        "Comment": "Acquire a lock using a conditional update to DynamoDB",
-        "Type": "Task",
-        "Resource": "arn:aws:states:::dynamodb:updateItem",
-        "Arguments": {
-          "TableName": "${DQSSemaphoreDynamoDbTableName}",
-          "Key": {
-            "LockName": {
-              "S": "{% $lock_name %}"
-            }
-          },
-          "ExpressionAttributeNames": {
-            "#currentlockcount": "currentlockcount",
-            "#lockownerid": "{% $lock_entry %}"
-          },
-          "ExpressionAttributeValues": {
-            ":increase": {
-              "N": "1"
-            },
-            ":limit": {
-              "N": "{% $string($concurrency_limit) %}"
-            },
-            ":lockacquiredtime": {
-              "S": "{% $states.context.State.EnteredTime %}"
-            }
-          },
-          "UpdateExpression": "SET #currentlockcount = #currentlockcount + :increase, #lockownerid = :lockacquiredtime",
-          "ConditionExpression": "currentlockcount <> :limit and attribute_not_exists(#lockownerid)",
-          "ReturnValues": "UPDATED_NEW"
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "Acquire Lock"
+        }
+      ],
+      "Next": "Acquire Lock"
+    },
+    "Get Current Lock Record": {
+      "Comment": "Check if this execution already holds a lock",
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Arguments": {
+        "TableName": "${DQSSemaphoreDynamoDbTableName}",
+        "ExpressionAttributeNames": {
+          "#lockownerid": "{% $lock_entry %}"
         },
-        "Retry": [
-          {
-            "ErrorEquals": [
-              "DynamoDB.AmazonDynamoDBException"
-            ],
-            "MaxAttempts": 0
-          },
-          {
-            "ErrorEquals": [
-              "States.ALL"
-            ],
-            "MaxAttempts": 6,
-            "BackoffRate": 2
-          }
-        ],
-        "Catch": [
-          {
-            "ErrorEquals": [
-              "DynamoDB.AmazonDynamoDBException"
-            ],
-            "Next": "Initialize Lock Item",
-            "Output": "$lockinfo.acquisitionerror"
-          },
-          {
-            "ErrorEquals": [
-              "DynamoDB.ConditionalCheckFailedException"
-            ],
-            "Next": "Get Current Lock Record",
-            "Output": "$lockinfo.acquisitionerror"
-          },
-          {
-            "ErrorEquals": [
-              "States.ALL"
-            ],
-            "Next": "ParentExceptionHandler",
-            "Output": "$.error"
-          }
-        ],
-        "Next": "Initiate DQS Lambda"
-      },
-      "Initialize Lock Item": {
-        "Comment": "Create the initial lock record if it doesn't exist",
-        "Type": "Task",
-        "Resource": "arn:aws:states:::dynamodb:putItem",
-        "Arguments": {
-          "TableName": "${DQSSemaphoreDynamoDbTableName}",
-          "Item": {
-            "LockName": {
-              "S": "{% $lock_name %}"
-            },
-            "currentlockcount": {
-              "N": "0"
-            }
-          },
-          "ConditionExpression": "LockName <> :lockname",
-          "ExpressionAttributeValues": {
-            ":lockname": {
-              "S": "{% $lock_name %}"
-            }
+        "Key": {
+          "LockName": {
+            "S": "{% $lock_name %}"
           }
         },
-        "Catch": [
-          {
-            "ErrorEquals": [
-              "States.ALL"
-            ],
-            "Next": "Acquire Lock"
-          }
-        ],
-        "Next": "Acquire Lock"
+        "ProjectionExpression": "#lockownerid"
       },
-      "Get Current Lock Record": {
-        "Comment": "Check if this execution already holds a lock",
-        "Type": "Task",
-        "Resource": "arn:aws:states:::dynamodb:getItem",
-        "Arguments": {
-          "TableName": "${DQSSemaphoreDynamoDbTableName}",
-          "ExpressionAttributeNames": {
-            "#lockownerid": "{% $lock_entry %}"
-          },
-          "Key": {
-            "LockName": {
-              "S": "{% $lock_name %}"
-            }
-          },
-          "ProjectionExpression": "#lockownerid"
-        },
-        "Assign": {
-          "Item": "{% $states.result.Item %}",
-          "ItemString": "{% $string($states.result.Item) %}"
-        },
-        "Output": "$lockinfo.currentlockitem",
-        "Next": "Check If Lock Already Acquired"
+      "Assign": {
+        "Item": "{% $states.result.Item %}",
+        "ItemString": "{% $string($states.result.Item) %}"
       },
-      "Check If Lock Already Acquired": {
-        "Comment": "Verify if this execution already has a lock",
-        "Type": "Choice",
-        "Choices": [
-          {
-            "Condition": "{% $exists($ItemString) and $contains($ItemString, 'Z') %}",
-            "Next": "Initiate DQS Lambda"
-          }
-        ],
-        "Default": "Wait to Get Lock"
-      },
-      "Wait to Get Lock": {
-        "Comment": "Wait before retrying to acquire the lock",
-        "Type": "Wait",
-        "Seconds": 30,
-        "Next": "Acquire Lock"
-      },
-      "Initiate DQS Lambda": {
+      "Output": "$lockinfo.currentlockitem",
+      "Next": "Check If Lock Already Acquired"
+    },
+    "Check If Lock Already Acquired": {
+      "Comment": "Verify if this execution already has a lock",
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $exists($ItemString) and $contains($ItemString, 'Z') %}",
+          "Next": "Initiate DQS Lambda"
+        }
+      ],
+      "Default": "Wait to Get Lock"
+    },
+    "Wait to Get Lock": {
+      "Comment": "Wait before retrying to acquire the lock",
+      "Type": "Wait",
+      "Seconds": 30,
+      "Next": "Acquire Lock"
+    },
+    "Initiate DQS Lambda": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Output": "{% $states.result.Payload %}",

--- a/state-machine.json
+++ b/state-machine.json
@@ -9,7 +9,7 @@
       "Assign": {
         "revision_id": "{% $exists($states.input) ? $states.input : null %}",
         "lock_name": "dqs-semaphore",
-        "concurrency_limit": 10,
+        "concurrency_limit": 2,
         "lock_entry": "{% $uuid() %}"
       }
     },

--- a/state-machine.json
+++ b/state-machine.json
@@ -3,173 +3,175 @@
   "Comment": "Data Quality Service State Machine",
   "StartAt": "InitialProcessInput",
   "States": {
-    "InitialProcessInput": {
-      "Type": "Pass",
-      "Next": "Validate Lock Inputs",
-      "Assign": {
-        "revision_id": "{% $exists($states.input) ? $states.input : null %}",
-        "lock_name": "dqs-semaphore",
-        "concurrency_limit": 2,
-        "lock_entry": "{% $uuid() %}"
-      }
-    },
-    "Validate Lock Inputs": {
-      "Type": "Choice",
-      "Default": "Lock Configuration Error",
-      "Choices": [
-        {
-          "Condition": "{% $exists(lock_name) and $type(lock_name) = 'string' and $exists(concurrency_limit) and $type(concurrency_limit) = 'number' and $exists(lock_entry) and $type(lock_entry) = 'string' %}",
-          "Next": "Acquire Lock"
+    "StartAt": "Initial Process Input",
+    "States": {
+      "Initial Process Input": {
+        "Type": "Pass",
+        "Next": "Validate Lock Inputs",
+        "Assign": {
+          "revision_id": "{% $exists($states.input) ? $states.input : null %}",
+          "lock_name": "dqs-semaphore",
+          "concurrency_limit": 2,
+          "lock_entry": "{% $uuid() %}"
         }
-      ]
-    },
-    "Lock Configuration Error": {
-      "Type": "Fail",
-      "Error": "InsufficientLockInput",
-      "Cause": "Lock parameters are missing or invalid"
-    },
-    "Acquire Lock": {
-      "Comment": "Acquire a lock using a conditional update to DynamoDB",
-      "Type": "Task",
-      "Resource": "arn:aws:states:::dynamodb:updateItem",
-      "Arguments": {
-        "TableName": "${DQSTableSemaphore}",
-        "Key": {
-          "LockName": {
-            "S": "{% $lock_name %}"
+      },
+      "Validate Lock Inputs": {
+        "Type": "Choice",
+        "Default": "Lock Configuration Error",
+        "Choices": [
+          {
+            "Condition": "{% $exists($lock_name) and $type($lock_name) = 'string' and $exists($concurrency_limit) and $type($concurrency_limit) = 'number' and $exists($lock_entry) and $type($lock_entry) = 'string' %}",
+            "Next": "Acquire Lock"
           }
-        },
-        "ExpressionAttributeNames": {
-          "#currentlockcount": "currentlockcount",
-          "#lockownerid": "{% $lock_entry %}"
-        },
-        "ExpressionAttributeValues": {
-          ":increase": {
-            "N": "1"
+        ]
+      },
+      "Lock Configuration Error": {
+        "Type": "Fail",
+        "Error": "InsufficientLockInput",
+        "Cause": "Lock parameters are missing or invalid"
+      },
+      "Acquire Lock": {
+        "Comment": "Acquire a lock using a conditional update to DynamoDB",
+        "Type": "Task",
+        "Resource": "arn:aws:states:::dynamodb:updateItem",
+        "Arguments": {
+          "TableName": "${DQSSemaphoreDynamoDbTableName}",
+          "Key": {
+            "LockName": {
+              "S": "{% $lock_name %}"
+            }
           },
-          ":limit": {
-            "N": "{% $string($concurrency_limit) %}"
+          "ExpressionAttributeNames": {
+            "#currentlockcount": "currentlockcount",
+            "#lockownerid": "{% $lock_entry %}"
           },
-          ":lockacquiredtime": {
-            "S": "{% $$.State.EnteredTime %}"
-          }
-        },
-        "UpdateExpression": "SET #currentlockcount = #currentlockcount + :increase, #lockownerid = :lockacquiredtime",
-        "ConditionExpression": "currentlockcount <> :limit and attribute_not_exists(#lockownerid)",
-        "ReturnValues": "UPDATED_NEW"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "DynamoDB.AmazonDynamoDBException"
-          ],
-          "MaxAttempts": 0
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "DynamoDB.AmazonDynamoDBException"
-          ],
-          "Next": "Initialize Lock Item",
-          "Output": "$.lockinfo.acquisitionerror"
-        },
-        {
-          "ErrorEquals": [
-            "DynamoDB.ConditionalCheckFailedException"
-          ],
-          "Next": "Get Current Lock Record",
-          "Output": "$.lockinfo.acquisitionerror"
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Next": "ParentExceptionHandler",
-          "Output": "$.error"
-        }
-      ],
-      "Next": "Initiate DQS Lambda"
-    },
-    "Initialize Lock Item": {
-      "Comment": "Create the initial lock record if it doesn't exist",
-      "Type": "Task",
-      "Resource": "arn:aws:states:::dynamodb:putItem",
-      "Arguments": {
-        "TableName": "${DQSTableSemaphore}",
-        "Item": {
-          "LockName": {
-            "S": "{% $lock_name %}"
+          "ExpressionAttributeValues": {
+            ":increase": {
+              "N": "1"
+            },
+            ":limit": {
+              "N": "{% $string($concurrency_limit) %}"
+            },
+            ":lockacquiredtime": {
+              "S": "{% $states.context.State.EnteredTime %}"
+            }
           },
-          "currentlockcount": {
-            "N": "0"
+          "UpdateExpression": "SET #currentlockcount = #currentlockcount + :increase, #lockownerid = :lockacquiredtime",
+          "ConditionExpression": "currentlockcount <> :limit and attribute_not_exists(#lockownerid)",
+          "ReturnValues": "UPDATED_NEW"
+        },
+        "Retry": [
+          {
+            "ErrorEquals": [
+              "DynamoDB.AmazonDynamoDBException"
+            ],
+            "MaxAttempts": 0
+          },
+          {
+            "ErrorEquals": [
+              "States.ALL"
+            ],
+            "MaxAttempts": 6,
+            "BackoffRate": 2
+          }
+        ],
+        "Catch": [
+          {
+            "ErrorEquals": [
+              "DynamoDB.AmazonDynamoDBException"
+            ],
+            "Next": "Initialize Lock Item",
+            "Output": "$lockinfo.acquisitionerror"
+          },
+          {
+            "ErrorEquals": [
+              "DynamoDB.ConditionalCheckFailedException"
+            ],
+            "Next": "Get Current Lock Record",
+            "Output": "$lockinfo.acquisitionerror"
+          },
+          {
+            "ErrorEquals": [
+              "States.ALL"
+            ],
+            "Next": "ParentExceptionHandler",
+            "Output": "$.error"
+          }
+        ],
+        "Next": "Initiate DQS Lambda"
+      },
+      "Initialize Lock Item": {
+        "Comment": "Create the initial lock record if it doesn't exist",
+        "Type": "Task",
+        "Resource": "arn:aws:states:::dynamodb:putItem",
+        "Arguments": {
+          "TableName": "${DQSSemaphoreDynamoDbTableName}",
+          "Item": {
+            "LockName": {
+              "S": "{% $lock_name %}"
+            },
+            "currentlockcount": {
+              "N": "0"
+            }
+          },
+          "ConditionExpression": "LockName <> :lockname",
+          "ExpressionAttributeValues": {
+            ":lockname": {
+              "S": "{% $lock_name %}"
+            }
           }
         },
-        "ConditionExpression": "LockName <> :lockname",
-        "ExpressionAttributeValues": {
-          ":lockname": {
-            "S": "{% $lock_name %}"
+        "Catch": [
+          {
+            "ErrorEquals": [
+              "States.ALL"
+            ],
+            "Next": "Acquire Lock"
           }
-        }
+        ],
+        "Next": "Acquire Lock"
       },
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Next": "Acquire Lock"
-        }
-      ],
-      "Next": "Acquire Lock"
-    },
-    "Get Current Lock Record": {
-      "Comment": "Check if this execution already holds a lock",
-      "Type": "Task",
-      "Resource": "arn:aws:states:::dynamodb:getItem",
-      "Arguments": {
-        "TableName": "${DQSTableSemaphore}",
-        "ExpressionAttributeNames": {
-          "#lockownerid": "{% $lock_entry %}"
+      "Get Current Lock Record": {
+        "Comment": "Check if this execution already holds a lock",
+        "Type": "Task",
+        "Resource": "arn:aws:states:::dynamodb:getItem",
+        "Arguments": {
+          "TableName": "${DQSSemaphoreDynamoDbTableName}",
+          "ExpressionAttributeNames": {
+            "#lockownerid": "{% $lock_entry %}"
+          },
+          "Key": {
+            "LockName": {
+              "S": "{% $lock_name %}"
+            }
+          },
+          "ProjectionExpression": "#lockownerid"
         },
-        "Key": {
-          "LockName": {
-            "S": "{% $lock_name %}"
+        "Assign": {
+          "Item": "{% $states.result.Item %}",
+          "ItemString": "{% $string($states.result.Item) %}"
+        },
+        "Output": "$lockinfo.currentlockitem",
+        "Next": "Check If Lock Already Acquired"
+      },
+      "Check If Lock Already Acquired": {
+        "Comment": "Verify if this execution already has a lock",
+        "Type": "Choice",
+        "Choices": [
+          {
+            "Condition": "{% $exists($ItemString) and $contains($ItemString, 'Z') %}",
+            "Next": "Initiate DQS Lambda"
           }
-        },
-        "ProjectionExpression": "#lockownerid"
+        ],
+        "Default": "Wait to Get Lock"
       },
-      "ResultSelector": {
-        "Item": "{% $.Item %}",
-        "ItemString": "{% $string($.Item) %}"
+      "Wait to Get Lock": {
+        "Comment": "Wait before retrying to acquire the lock",
+        "Type": "Wait",
+        "Seconds": 30,
+        "Next": "Acquire Lock"
       },
-      "Output": "$.lockinfo.currentlockitem",
-      "Next": "Check If Lock Already Acquired"
-    },
-    "Check If Lock Already Acquired": {
-      "Comment": "Verify if this execution already has a lock",
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Condition": "{% $exists($.lockinfo.currentlockitem.ItemString) and $contains($.lockinfo.currentlockitem.ItemString, 'Z') %}",
-          "Next": "Initiate DQS Lambda"
-        }
-      ],
-      "Default": "Wait to Get Lock"
-    },
-    "Wait to Get Lock": {
-      "Comment": "Wait before retrying to acquire the lock",
-      "Type": "Wait",
-      "Seconds": 3,
-      "Next": "Acquire Lock"
-    },
-    "Initiate DQS Lambda": {
+      "Initiate DQS Lambda": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Output": "{% $states.result.Payload %}",
@@ -198,7 +200,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "Release Lock On Error",
+          "Next": "ReleaseLockExceptionHandler",
           "Output": "$.error"
         }
       ]
@@ -213,7 +215,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "Release Lock On Error",
+          "Next": "ReleaseLockExceptionHandler",
           "Output": "$.error"
         }
       ],
@@ -1245,7 +1247,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "Release Lock On Error",
+          "Next": "ReleaseLockExceptionHandler",
           "Output": "$.error"
         }
       ]
@@ -1305,11 +1307,11 @@
       ],
       "Next": "Success"
     },
-    "Release Lock On Error": {
+    "ReleaseLockExceptionHandler": {
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:updateItem",
       "Arguments": {
-        "TableName": "${DQSTableSemaphore}",
+        "TableName": "${DQSSemaphoreDynamoDbTableName}",
         "Key": {
           "LockName": {
             "S": "{% $lock_name %}"

--- a/state-machine.json
+++ b/state-machine.json
@@ -17,32 +17,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "And": [
-            {
-              "Variable": "$.lock_name",
-              "IsPresent": true
-            },
-            {
-              "Variable": "$.lock_name",
-              "IsString": true
-            },
-            {
-              "Variable": "$.concurrency_limit",
-              "IsPresent": true
-            },
-            {
-              "Variable": "$.concurrency_limit",
-              "IsNumeric": true
-            },
-            {
-              "Variable": "$.lock_entry",
-              "IsPresent": true
-            },
-            {
-              "Variable": "$.lock_entry",
-              "IsString": true
-            }
-          ],
+          "Condition": "{% $exists($.lock_name) and $type($.lock_name) = 'string' and $exists($.concurrency_limit) and $type($.concurrency_limit) = 'number' and $exists($.lock_entry) and $type($.lock_entry) = 'string' %}",
           "Next": "Acquire Lock"
         }
       ],
@@ -57,26 +32,26 @@
       "Comment": "Acquire a lock using a conditional update to DynamoDB",
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:updateItem",
-      "Parameters": {
+      "Arguments": {
         "TableName": "${DQSTableSemaphore}",
         "Key": {
           "LockName": {
-            "S.$": "$.lock_name"
+            "S": "{% $.lock_name %}"
           }
         },
         "ExpressionAttributeNames": {
           "#currentlockcount": "currentlockcount",
-          "#lockownerid.$": "$.lock_entry"
+          "#lockownerid": "{% $.lock_entry %}"
         },
         "ExpressionAttributeValues": {
           ":increase": {
             "N": "1"
           },
           ":limit": {
-            "N.$": "States.JsonToString($.concurrency_limit)"
+            "N": "{% $string($.concurrency_limit) %}"
           },
           ":lockacquiredtime": {
-            "S.$": "$$.State.EnteredTime"
+            "S": "{% $$.State.EnteredTime %}"
           }
         },
         "UpdateExpression": "SET #currentlockcount = #currentlockcount + :increase, #lockownerid = :lockacquiredtime",
@@ -127,11 +102,11 @@
       "Comment": "Create the initial lock record if it doesn't exist",
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:putItem",
-      "Parameters": {
+      "Arguments": {
         "TableName": "${DQSTableSemaphore}",
         "Item": {
           "LockName": {
-            "S.$": "$.lock_name"
+            "S": "{% $.lock_name %}"
           },
           "currentlockcount": {
             "N": "0"
@@ -140,7 +115,7 @@
         "ConditionExpression": "LockName <> :lockname",
         "ExpressionAttributeValues": {
           ":lockname": {
-            "S.$": "$.lock_name"
+            "S": "{% $.lock_name %}"
           }
         }
       },
@@ -160,21 +135,21 @@
       "Comment": "Check if this execution already holds a lock",
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:getItem",
-      "Parameters": {
+      "Arguments": {
         "TableName": "${DQSTableSemaphore}",
         "ExpressionAttributeNames": {
-          "#lockownerid.$": "$.lock_entry"
+          "#lockownerid": "{% $.lock_entry %}"
         },
         "Key": {
           "LockName": {
-            "S.$": "$.lock_name"
+            "S": "{% $.lock_name %}"
           }
         },
         "ProjectionExpression": "#lockownerid"
       },
       "ResultSelector": {
-        "Item.$": "$.Item",
-        "ItemString.$": "States.JsonToString($.Item)"
+        "Item": "{% $.Item %}",
+        "ItemString": "{% $string($.Item) %}"
       },
       "ResultPath": "$.lockinfo.currentlockitem",
       "Next": "Check If Lock Already Acquired"
@@ -184,16 +159,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "And": [
-            {
-              "Variable": "$.lockinfo.currentlockitem.ItemString",
-              "IsPresent": true
-            },
-            {
-              "Variable": "$.lockinfo.currentlockitem.ItemString",
-              "StringMatches": "*Z*"
-            }
-          ],
+          "Condition": "{% $exists($.lockinfo.currentlockitem.ItemString) and $contains($.lockinfo.currentlockitem.ItemString, 'Z') %}",
           "Next": "Initiate DQS Lambda"
         }
       ],
@@ -1289,16 +1255,16 @@
     "Release Lock": {
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:updateItem",
-      "Parameters": {
+      "Arguments": {
         "TableName": "${DQSTableSemaphore}",
         "Key": {
           "LockName": {
-            "S.$": "$.lock_name"
+            "S": "{% $.lock_name %}"
           }
         },
         "ExpressionAttributeNames": {
           "#currentlockcount": "currentlockcount",
-          "#lockownerid.$": "$.lock_entry"
+          "#lockownerid": "{% $.lock_entry %}"
         },
         "ExpressionAttributeValues": {
           ":decrease": {
@@ -1345,16 +1311,16 @@
     "Release Lock On Error": {
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:updateItem",
-      "Parameters": {
+      "Arguments": {
         "TableName": "${DQSTableSemaphore}",
         "Key": {
           "LockName": {
-            "S.$": "$.lock_name"
+            "S": "{% $.lock_name %}"
           }
         },
         "ExpressionAttributeNames": {
           "#currentlockcount": "currentlockcount",
-          "#lockownerid.$": "$.lock_entry"
+          "#lockownerid": "{% $.lock_entry %}"
         },
         "ExpressionAttributeValues": {
           ":decrease": {

--- a/state-machine.json
+++ b/state-machine.json
@@ -5,10 +5,205 @@
   "States": {
     "InitialProcessInput": {
       "Type": "Pass",
-      "Next": "Initiate DQS Lambda",
+      "Next": "Validate Lock Inputs",
       "Assign": {
-        "revision_id": "{% $exists($states.input) ? $states.input : null %}"
+        "revision_id": "{% $exists($states.input) ? $states.input : null %}",
+        "lock_name": "dqs-semaphore",
+        "concurrency_limit": 10,
+        "lock_entry": "{% $uuid() %}"
       }
+    },
+    "Validate Lock Inputs": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.lock_name",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.lock_name",
+              "IsString": true
+            },
+            {
+              "Variable": "$.concurrency_limit",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.concurrency_limit",
+              "IsNumeric": true
+            },
+            {
+              "Variable": "$.lock_entry",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.lock_entry",
+              "IsString": true
+            }
+          ],
+          "Next": "Acquire Lock"
+        }
+      ],
+      "Default": "Lock Configuration Error"
+    },
+    "Lock Configuration Error": {
+      "Type": "Fail",
+      "Error": "InsufficientLockInput",
+      "Cause": "Lock parameters are missing or invalid"
+    },
+    "Acquire Lock": {
+      "Comment": "Acquire a lock using a conditional update to DynamoDB",
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Parameters": {
+        "TableName": "${DQSTableSemaphore}",
+        "Key": {
+          "LockName": {
+            "S.$": "$.lock_name"
+          }
+        },
+        "ExpressionAttributeNames": {
+          "#currentlockcount": "currentlockcount",
+          "#lockownerid.$": "$.lock_entry"
+        },
+        "ExpressionAttributeValues": {
+          ":increase": {
+            "N": "1"
+          },
+          ":limit": {
+            "N.$": "States.JsonToString($.concurrency_limit)"
+          },
+          ":lockacquiredtime": {
+            "S.$": "$$.State.EnteredTime"
+          }
+        },
+        "UpdateExpression": "SET #currentlockcount = #currentlockcount + :increase, #lockownerid = :lockacquiredtime",
+        "ConditionExpression": "currentlockcount <> :limit and attribute_not_exists(#lockownerid)",
+        "ReturnValues": "UPDATED_NEW"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.AmazonDynamoDBException"
+          ],
+          "MaxAttempts": 0
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.AmazonDynamoDBException"
+          ],
+          "Next": "Initialize Lock Item",
+          "ResultPath": "$.lockinfo.acquisitionerror"
+        },
+        {
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
+          "Next": "Get Current Lock Record",
+          "ResultPath": "$.lockinfo.acquisitionerror"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ParentExceptionHandler",
+          "ResultPath": "$.error"
+        }
+      ],
+      "Next": "Initiate DQS Lambda"
+    },
+    "Initialize Lock Item": {
+      "Comment": "Create the initial lock record if it doesn't exist",
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:putItem",
+      "Parameters": {
+        "TableName": "${DQSTableSemaphore}",
+        "Item": {
+          "LockName": {
+            "S.$": "$.lock_name"
+          },
+          "currentlockcount": {
+            "N": "0"
+          }
+        },
+        "ConditionExpression": "LockName <> :lockname",
+        "ExpressionAttributeValues": {
+          ":lockname": {
+            "S.$": "$.lock_name"
+          }
+        }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "Acquire Lock",
+          "ResultPath": null
+        }
+      ],
+      "Next": "Acquire Lock",
+      "ResultPath": null
+    },
+    "Get Current Lock Record": {
+      "Comment": "Check if this execution already holds a lock",
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Parameters": {
+        "TableName": "${DQSTableSemaphore}",
+        "ExpressionAttributeNames": {
+          "#lockownerid.$": "$.lock_entry"
+        },
+        "Key": {
+          "LockName": {
+            "S.$": "$.lock_name"
+          }
+        },
+        "ProjectionExpression": "#lockownerid"
+      },
+      "ResultSelector": {
+        "Item.$": "$.Item",
+        "ItemString.$": "States.JsonToString($.Item)"
+      },
+      "ResultPath": "$.lockinfo.currentlockitem",
+      "Next": "Check If Lock Already Acquired"
+    },
+    "Check If Lock Already Acquired": {
+      "Comment": "Verify if this execution already has a lock",
+      "Type": "Choice",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.lockinfo.currentlockitem.ItemString",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.lockinfo.currentlockitem.ItemString",
+              "StringMatches": "*Z*"
+            }
+          ],
+          "Next": "Initiate DQS Lambda"
+        }
+      ],
+      "Default": "Wait to Get Lock"
+    },
+    "Wait to Get Lock": {
+      "Comment": "Wait before retrying to acquire the lock",
+      "Type": "Wait",
+      "Seconds": 3,
+      "Next": "Acquire Lock"
     },
     "Initiate DQS Lambda": {
       "Type": "Task",
@@ -39,36 +234,10 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "ParentExceptionHandler"
+          "Next": "Release Lock On Error",
+          "ResultPath": "$.error"
         }
       ]
-    },
-    "ParentExceptionHandler": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Output": "{% $states.result.Payload %}",
-      "Arguments": {
-        "FunctionName": "${GeneralErrorLambdaArn}",
-        "Payload":{
-          "Error": "{% $states.input %}",
-          "revision_id": "{% $revision_id %}"
-          }
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "IntervalSeconds": 1,
-          "MaxAttempts": 3,
-          "BackoffRate": 2,
-          "JitterStrategy": "FULL"
-        }
-      ],
-      "End": true
     },
     "Map": {
       "Type": "Map",
@@ -80,7 +249,8 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "ParentExceptionHandler"
+          "Next": "Release Lock On Error",
+          "ResultPath": "$.error"
         }
       ],
       "Output": {
@@ -1105,15 +1275,151 @@
           "JitterStrategy": "FULL"
         }
       ],
-      "End": true,
+      "Next": "Release Lock",
       "Catch": [
         {
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "ParentExceptionHandler"
+          "Next": "Release Lock On Error",
+          "ResultPath": "$.error"
         }
       ]
+    },
+    "Release Lock": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Parameters": {
+        "TableName": "${DQSTableSemaphore}",
+        "Key": {
+          "LockName": {
+            "S.$": "$.lock_name"
+          }
+        },
+        "ExpressionAttributeNames": {
+          "#currentlockcount": "currentlockcount",
+          "#lockownerid.$": "$.lock_entry"
+        },
+        "ExpressionAttributeValues": {
+          ":decrease": {
+            "N": "1"
+          }
+        },
+        "UpdateExpression": "SET #currentlockcount = #currentlockcount - :decrease REMOVE #lockownerid",
+        "ConditionExpression": "attribute_exists(#lockownerid)",
+        "ReturnValues": "UPDATED_NEW"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
+          "MaxAttempts": 0
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 5,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
+          "Next": "Success",
+          "ResultPath": null
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ParentExceptionHandler",
+          "ResultPath": "$.error"
+        }
+      ],
+      "Next": "Success"
+    },
+    "Release Lock On Error": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Parameters": {
+        "TableName": "${DQSTableSemaphore}",
+        "Key": {
+          "LockName": {
+            "S.$": "$.lock_name"
+          }
+        },
+        "ExpressionAttributeNames": {
+          "#currentlockcount": "currentlockcount",
+          "#lockownerid.$": "$.lock_entry"
+        },
+        "ExpressionAttributeValues": {
+          ":decrease": {
+            "N": "1"
+          }
+        },
+        "UpdateExpression": "SET #currentlockcount = #currentlockcount - :decrease REMOVE #lockownerid",
+        "ConditionExpression": "attribute_exists(#lockownerid)",
+        "ReturnValues": "UPDATED_NEW"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
+          "MaxAttempts": 0
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 5,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Next": "ParentExceptionHandler",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ParentExceptionHandler",
+          "ResultPath": "$.releaseError"
+        }
+      ]
+    },
+    "ParentExceptionHandler": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Output": "{% $states.result.Payload %}",
+      "Arguments": {
+        "FunctionName": "${GeneralErrorLambdaArn}",
+        "Payload":{
+          "Error": "{% $states.input %}",
+          "revision_id": "{% $revision_id %}"
+          }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "End": true
+    },
+    "Success": {
+      "Type": "Succeed"
     }
   }
 }

--- a/state-machine.json
+++ b/state-machine.json
@@ -15,13 +15,13 @@
     },
     "Validate Lock Inputs": {
       "Type": "Choice",
+      "Default": "Lock Configuration Error",
       "Choices": [
         {
-          "Condition": "{% $exists($.lock_name) and $type($.lock_name) = 'string' and $exists($.concurrency_limit) and $type($.concurrency_limit) = 'number' and $exists($.lock_entry) and $type($.lock_entry) = 'string' %}",
+          "Condition": "{% $exists(lock_name) and $type(lock_name) = 'string' and $exists(concurrency_limit) and $type(concurrency_limit) = 'number' and $exists(lock_entry) and $type(lock_entry) = 'string' %}",
           "Next": "Acquire Lock"
         }
-      ],
-      "Default": "Lock Configuration Error"
+      ]
     },
     "Lock Configuration Error": {
       "Type": "Fail",
@@ -36,19 +36,19 @@
         "TableName": "${DQSTableSemaphore}",
         "Key": {
           "LockName": {
-            "S": "{% $.lock_name %}"
+            "S": "{% $lock_name %}"
           }
         },
         "ExpressionAttributeNames": {
           "#currentlockcount": "currentlockcount",
-          "#lockownerid": "{% $.lock_entry %}"
+          "#lockownerid": "{% $lock_entry %}"
         },
         "ExpressionAttributeValues": {
           ":increase": {
             "N": "1"
           },
           ":limit": {
-            "N": "{% $string($.concurrency_limit) %}"
+            "N": "{% $string($concurrency_limit) %}"
           },
           ":lockacquiredtime": {
             "S": "{% $$.State.EnteredTime %}"
@@ -79,21 +79,21 @@
             "DynamoDB.AmazonDynamoDBException"
           ],
           "Next": "Initialize Lock Item",
-          "ResultPath": "$.lockinfo.acquisitionerror"
+          "Output": "$.lockinfo.acquisitionerror"
         },
         {
           "ErrorEquals": [
             "DynamoDB.ConditionalCheckFailedException"
           ],
           "Next": "Get Current Lock Record",
-          "ResultPath": "$.lockinfo.acquisitionerror"
+          "Output": "$.lockinfo.acquisitionerror"
         },
         {
           "ErrorEquals": [
             "States.ALL"
           ],
           "Next": "ParentExceptionHandler",
-          "ResultPath": "$.error"
+          "Output": "$.error"
         }
       ],
       "Next": "Initiate DQS Lambda"
@@ -106,7 +106,7 @@
         "TableName": "${DQSTableSemaphore}",
         "Item": {
           "LockName": {
-            "S": "{% $.lock_name %}"
+            "S": "{% $lock_name %}"
           },
           "currentlockcount": {
             "N": "0"
@@ -115,7 +115,7 @@
         "ConditionExpression": "LockName <> :lockname",
         "ExpressionAttributeValues": {
           ":lockname": {
-            "S": "{% $.lock_name %}"
+            "S": "{% $lock_name %}"
           }
         }
       },
@@ -124,12 +124,10 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "Acquire Lock",
-          "ResultPath": null
+          "Next": "Acquire Lock"
         }
       ],
-      "Next": "Acquire Lock",
-      "ResultPath": null
+      "Next": "Acquire Lock"
     },
     "Get Current Lock Record": {
       "Comment": "Check if this execution already holds a lock",
@@ -138,11 +136,11 @@
       "Arguments": {
         "TableName": "${DQSTableSemaphore}",
         "ExpressionAttributeNames": {
-          "#lockownerid": "{% $.lock_entry %}"
+          "#lockownerid": "{% $lock_entry %}"
         },
         "Key": {
           "LockName": {
-            "S": "{% $.lock_name %}"
+            "S": "{% $lock_name %}"
           }
         },
         "ProjectionExpression": "#lockownerid"
@@ -151,7 +149,7 @@
         "Item": "{% $.Item %}",
         "ItemString": "{% $string($.Item) %}"
       },
-      "ResultPath": "$.lockinfo.currentlockitem",
+      "Output": "$.lockinfo.currentlockitem",
       "Next": "Check If Lock Already Acquired"
     },
     "Check If Lock Already Acquired": {
@@ -201,7 +199,7 @@
             "States.ALL"
           ],
           "Next": "Release Lock On Error",
-          "ResultPath": "$.error"
+          "Output": "$.error"
         }
       ]
     },
@@ -216,7 +214,7 @@
             "States.ALL"
           ],
           "Next": "Release Lock On Error",
-          "ResultPath": "$.error"
+          "Output": "$.error"
         }
       ],
       "Output": {
@@ -1248,7 +1246,7 @@
             "States.ALL"
           ],
           "Next": "Release Lock On Error",
-          "ResultPath": "$.error"
+          "Output": "$.error"
         }
       ]
     },
@@ -1259,12 +1257,12 @@
         "TableName": "${DQSTableSemaphore}",
         "Key": {
           "LockName": {
-            "S": "{% $.lock_name %}"
+            "S": "{% $lock_name %}"
           }
         },
         "ExpressionAttributeNames": {
           "#currentlockcount": "currentlockcount",
-          "#lockownerid": "{% $.lock_entry %}"
+          "#lockownerid": "{% $lock_entry %}"
         },
         "ExpressionAttributeValues": {
           ":decrease": {
@@ -1295,15 +1293,14 @@
           "ErrorEquals": [
             "DynamoDB.ConditionalCheckFailedException"
           ],
-          "Next": "Success",
-          "ResultPath": null
+          "Next": "Success"
         },
         {
           "ErrorEquals": [
             "States.ALL"
           ],
           "Next": "ParentExceptionHandler",
-          "ResultPath": "$.error"
+          "Output": "$.error"
         }
       ],
       "Next": "Success"
@@ -1315,12 +1312,12 @@
         "TableName": "${DQSTableSemaphore}",
         "Key": {
           "LockName": {
-            "S": "{% $.lock_name %}"
+            "S": "{% $lock_name %}"
           }
         },
         "ExpressionAttributeNames": {
           "#currentlockcount": "currentlockcount",
-          "#lockownerid": "{% $.lock_entry %}"
+          "#lockownerid": "{% $lock_entry %}"
         },
         "ExpressionAttributeValues": {
           ":decrease": {
@@ -1353,7 +1350,7 @@
             "States.ALL"
           ],
           "Next": "ParentExceptionHandler",
-          "ResultPath": "$.releaseError"
+          "Output": "$.releaseError"
         }
       ]
     },

--- a/template.yaml
+++ b/template.yaml
@@ -1639,6 +1639,7 @@ Resources:
         CheckErrorLambdaArn: !GetAtt CheckErrorLambda.Arn
         PipelineMonitorLambdaArn: !GetAtt PipelineMonitorLambda.Arn
         S3BucketName: !Sub 'bodds-${Environment}'
+        DQSTableSemaphore: !Ref DQSTableSemaphore
         
       Name: !Sub '${ProjectName}-${Environment}-sm'
       Policies:
@@ -1724,3 +1725,17 @@ Resources:
             ExpirationInDays: 7
             NoncurrentVersionExpiration:
               NoncurrentDays: 7
+
+  DQSTableSemaphore:
+    # checkov:skip=CKV_AWS_28: DB stores lock to prevent more than one state machine from executing at the same time
+    # checkov:skip=CKV_AWS_119: Data is just a job id
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub '${ProjectName}-${Environment}-semaphore'
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: LockName
+          AttributeType: S
+      KeySchema:
+        - AttributeName: LockName
+          KeyType: HASH

--- a/template.yaml
+++ b/template.yaml
@@ -1640,7 +1640,7 @@ Resources:
         PipelineMonitorLambdaArn: !GetAtt PipelineMonitorLambda.Arn
         S3BucketName: !Sub 'bodds-${Environment}'
         DQSTableSemaphore: !Ref DQSTableSemaphore
-        
+
       Name: !Sub '${ProjectName}-${Environment}-sm'
       Policies:
         - LambdaInvokePolicy:
@@ -1739,3 +1739,14 @@ Resources:
       KeySchema:
         - AttributeName: LockName
           KeyType: HASH
+
+  StateMachineToDynamoLockTable:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source:
+        Id: DQSStateMachine
+      Destination:
+        Id: DQSTableSemaphore
+      Permissions:
+        - Read
+        - Write

--- a/template.yaml
+++ b/template.yaml
@@ -1208,9 +1208,9 @@ Resources:
       KmsKeyId: !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'
       RetentionInDays: 30
 
-  ###########################################
-  ####       DATA PREFETCH LAMBDA        ####
-  ###########################################
+  ##############################
+  #### DATA PREFETCH LAMBDA ####
+  ##############################
   DataPreFetchLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -1258,9 +1258,9 @@ Resources:
       KmsKeyId: !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'
       RetentionInDays: 30
 
-  ###########################################
-  ####            INITIATE DQS           ####
-  ###########################################
+  ######################
+  #### INITIATE DQS ####
+  ######################
   InitiateDQSLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -1314,9 +1314,9 @@ Resources:
       KmsKeyId: !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'
       RetentionInDays: 30
 
-  ###########################################
-  ##    General Error Handler Lambda     ####
-  ###########################################
+  ###############################
+  #### GENERAL ERROR HANDLER ####
+  ###############################
   GeneralErrorLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -1375,9 +1375,9 @@ Resources:
       KmsKeyId: !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'
       RetentionInDays: 30
         
-  ###########################################
-  ##      Check Error Handler Lambda      ####
-  ###########################################
+  #############################
+  #### CHECK ERROR HANDLER ####
+  #############################
   CheckErrorLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -1549,9 +1549,9 @@ Resources:
       RetentionInDays: 30
 
 
-  #####################################
-  ####   DEAD LETTER QUEUE LAMBDA  ####
-  #####################################
+  ##################################
+  #### DEAD LETTER QUEUE LAMBDA ####
+  ##################################
   DeadLetterQueueLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -1612,6 +1612,9 @@ Resources:
       KmsKeyId: !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'
       RetentionInDays: 30
 
+  #######################
+  #### STATE MACHINE ####
+  #######################
   DQSStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
@@ -1638,8 +1641,8 @@ Resources:
         GeneralErrorLambdaArn: !GetAtt GeneralErrorLambda.Arn
         CheckErrorLambdaArn: !GetAtt CheckErrorLambda.Arn
         PipelineMonitorLambdaArn: !GetAtt PipelineMonitorLambda.Arn
+        DQSSemaphoreDynamoDbTableName: !Ref DQSSemaphore
         S3BucketName: !Sub 'bodds-${Environment}'
-        DQSTableSemaphore: !Ref DQSTableSemaphore
 
       Name: !Sub '${ProjectName}-${Environment}-sm'
       Policies:
@@ -1699,7 +1702,6 @@ Resources:
                 - kms:Decrypt
               Resource: !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'
  
-
   DQSCacheBucket:
     Type:  AWS::S3::Bucket
     Properties:
@@ -1726,19 +1728,31 @@ Resources:
             NoncurrentVersionExpiration:
               NoncurrentDays: 7
 
-  DQSTableSemaphore:
+  ##################
+  #### DYNAMODB ####
+  ##################
+  DQSSemaphore:
     # checkov:skip=CKV_AWS_28: DB stores lock to prevent more than one state machine from executing at the same time
     # checkov:skip=CKV_AWS_119: Data is just a job id
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Sub '${ProjectName}-${Environment}-semaphore'
-      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: LockName
           AttributeType: S
       KeySchema:
         - AttributeName: LockName
           KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: false
+      SSESpecification:
+        SSEEnabled: true
+        SSEType: 'KMS'
+        KMSMasterKeyId: !If
+          - IsNotLocal
+          - !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'
+          - !Ref AWS::NoValue
 
   StateMachineToDynamoLockTable:
     Type: AWS::Serverless::Connector
@@ -1746,7 +1760,7 @@ Resources:
       Source:
         Id: DQSStateMachine
       Destination:
-        Id: DQSTableSemaphore
+        Id: DQSSemaphore
       Permissions:
         - Read
         - Write


### PR DESCRIPTION
Limit the concurrent executions of the step function with semaphore

Based on example from here: https://github.com/aws-samples/aws-stepfunctions-examples/tree/main/sam/app-meeting-summarization/statemachines

JIRA ticket - https://kpmgengineering.atlassian.net/browse/BODS-8652