### PR TITLE
fix(ExceptionHandler): Call ParentExceptionHandler before ReleaseLockExceptionHandler

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.1.63
+version: v1.1.64

--- a/state-machine.json
+++ b/state-machine.json
@@ -198,7 +198,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "ReleaseLockExceptionHandler",
+          "Next": "ParentExceptionHandler",
           "Output": "$.error"
         }
       ]
@@ -213,7 +213,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "ReleaseLockExceptionHandler",
+          "Next": "ParentExceptionHandler",
           "Output": "$.error"
         }
       ],
@@ -1245,7 +1245,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "ReleaseLockExceptionHandler",
+          "Next": "ParentExceptionHandler",
           "Output": "$.error"
         }
       ]
@@ -1305,6 +1305,41 @@
       ],
       "Next": "Success"
     },
+    "ParentExceptionHandler": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Output": "{% $states.result.Payload %}",
+      "Arguments": {
+        "FunctionName": "${GeneralErrorLambdaArn}",
+        "Payload": {
+          "Error": "{% $states.input %}",
+          "revision_id": "{% $revision_id %}"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "ReleaseLockExceptionHandler",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ReleaseLockExceptionHandler",
+        }
+      ]
+    },
     "ReleaseLockExceptionHandler": {
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:updateItem",
@@ -1341,42 +1376,6 @@
           ],
           "MaxAttempts": 5,
           "BackoffRate": 1.5
-        }
-      ],
-      "Next": "ParentExceptionHandler",
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Next": "ParentExceptionHandler",
-          "Output": "$.releaseError"
-        }
-      ]
-    },
-    "ParentExceptionHandler": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Output": "{% $states.result.Payload %}",
-      "Arguments": {
-        "FunctionName": "${GeneralErrorLambdaArn}",
-        "Payload": {
-          "Error": "{% $states.input %}",
-          "revision_id": "{% $revision_id %}"
-        }
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "IntervalSeconds": 1,
-          "MaxAttempts": 3,
-          "BackoffRate": 2,
-          "JitterStrategy": "FULL"
         }
       ],
       "End": true


### PR DESCRIPTION
After the introduction of the Release Lock Exception Handler, the Parent Exception Handler will not receive error info. In this PR we swap the order so that the Parent Exception Handler is able to process the error before calling the Release Lock Exception Handler